### PR TITLE
S3Backend: Enable pathStyleAccess in AWS Client

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ target
 *.ipr
 *.iws
 .idea
+.DS_Store

--- a/jackrabbit-aws-ext/src/main/java/org/apache/jackrabbit/aws/ext/S3Constants.java
+++ b/jackrabbit-aws-ext/src/main/java/org/apache/jackrabbit/aws/ext/S3Constants.java
@@ -96,16 +96,11 @@ public final class S3Constants {
      *  Constant to set SSE_S3 encryption.
      */
     public static final String S3_ENCRYPTION_SSE_S3 = "SSE_S3";
-
+    
     /**
-     *  Constant to set proxy host.
+     * Path style access flag true/false
      */
-    public static final String PROXY_HOST = "proxyHost";
-
-    /**
-     *  Constant to set proxy port.
-     */
-    public static final String PROXY_PORT = "proxyPort";
+    public static final String S3_PATH_STYLE_ACCESS = "pathStyleAccess";
 
     /**
      * private constructor so that class cannot initialized from outside.


### PR DESCRIPTION
Enable pathStyleAccess in the S3 DataStore. Some on premise S3 compatible storage solutions require path style access to S3 object i.e. http://s3EndPoint/s3Bucket/objectKey instead of default http://s3Bucket.s3EndPoint/objectKey

New property pathAccessStyle=true is used to enable path style access.
