### PR TITLE
JCR-4006: Fixing TestCachingFDS tests

### DIFF
--- a/jackrabbit-aws-ext/src/main/java/org/apache/jackrabbit/aws/ext/ds/S3Backend.java
+++ b/jackrabbit-aws-ext/src/main/java/org/apache/jackrabbit/aws/ext/ds/S3Backend.java
@@ -36,11 +36,11 @@ import java.util.concurrent.TimeUnit;
 import org.apache.jackrabbit.aws.ext.S3Constants;
 import org.apache.jackrabbit.aws.ext.S3RequestDecorator;
 import org.apache.jackrabbit.aws.ext.Utils;
+import org.apache.jackrabbit.core.data.AbstractBackend;
 import org.apache.jackrabbit.core.data.AsyncTouchCallback;
 import org.apache.jackrabbit.core.data.AsyncTouchResult;
 import org.apache.jackrabbit.core.data.AsyncUploadCallback;
 import org.apache.jackrabbit.core.data.AsyncUploadResult;
-import org.apache.jackrabbit.core.data.Backend;
 import org.apache.jackrabbit.core.data.CachingDataStore;
 import org.apache.jackrabbit.core.data.DataIdentifier;
 import org.apache.jackrabbit.core.data.DataStoreException;
@@ -71,7 +71,7 @@ import com.amazonaws.util.StringUtils;
 /**
  * A data store backend that stores data on Amazon S3.
  */
-public class S3Backend implements Backend {
+public class S3Backend extends AbstractBackend {
 
     /**
      * Logger instance.
@@ -86,13 +86,9 @@ public class S3Backend implements Backend {
 
     private TransferManager tmx;
 
-    private CachingDataStore store;
-
     private Properties properties;
 
     private Date startTime;
-    
-    private ThreadPoolExecutor asyncWriteExecuter;
 
     private S3RequestDecorator s3ReqDecorator;
 
@@ -101,8 +97,10 @@ public class S3Backend implements Backend {
      * aws.properties. It creates S3 bucket if it doesn't pre-exist in S3.
      */
     @Override
-    public void init(CachingDataStore store, String homeDir, String config)
+    public void init(CachingDataStore cachingDataStore, String homeDir, String config)
             throws DataStoreException {
+        super.init(cachingDataStore, homeDir, config);
+
         Properties initProps = null;
         //Check is configuration is already provided. That takes precedence
         //over config provided via file based config
@@ -120,19 +118,19 @@ public class S3Backend implements Backend {
             }
             this.properties = initProps;
         }
-        init(store, homeDir, initProps);
+
+        init(cachingDataStore, homeDir, initProps);
     }
 
-    public void init(CachingDataStore store, String homeDir, Properties prop)
+    public void init(CachingDataStore cachingDataStore, String homeDir, Properties prop)
             throws DataStoreException {
-
         ClassLoader contextClassLoader = Thread.currentThread().getContextClassLoader();
         try {
             startTime = new Date();
             Thread.currentThread().setContextClassLoader(
                 getClass().getClassLoader());
             LOG.debug("init");
-            this.store = store;
+            setCachingDataStore(cachingDataStore);
             s3ReqDecorator = new S3RequestDecorator(prop);
 
             s3service = Utils.openService(prop);
@@ -184,9 +182,8 @@ public class S3Backend implements Backend {
                 asyncWritePoolSize = Integer.parseInt(maxConnsStr)
                     - writeThreads;
             }
-            
-            asyncWriteExecuter = (ThreadPoolExecutor) Executors.newFixedThreadPool(
-                asyncWritePoolSize, new NamedThreadFactory("s3-write-worker"));
+            setAsyncWritePoolSize(asyncWritePoolSize);
+
             String renameKeyProp = prop.getProperty(S3Constants.S3_RENAME_KEYS);
             boolean renameKeyBool = (renameKeyProp == null || "".equals(renameKeyProp))
                     ? false
@@ -226,7 +223,7 @@ public class S3Backend implements Backend {
             throw new IllegalArgumentException(
                 "callback parameter cannot be null in asyncUpload");
         }
-        asyncWriteExecuter.execute(new AsyncUploadJob(identifier, file,
+        getAsyncWriteExecutor().execute(new AsyncUploadJob(identifier, file,
             callback));
     }
 
@@ -327,7 +324,7 @@ public class S3Backend implements Backend {
             Thread.currentThread().setContextClassLoader(
                 getClass().getClassLoader());
 
-            asyncWriteExecuter.execute(new Runnable() {
+            getAsyncWriteExecutor().execute(new Runnable() {
                 @Override
                 public void run() {
                     try {
@@ -537,13 +534,13 @@ public class S3Backend implements Backend {
                     long lastModified = s3ObjSumm.getLastModified().getTime();
                     LOG.debug("Identifier [{}]'s lastModified = [{}]", identifier, lastModified);
                     if (lastModified < min
-                        && store.confirmDelete(identifier)
+                        && getCachingDataStore().confirmDelete(identifier)
                          // confirm once more that record's lastModified < min
                         //  order is important here
                         && s3service.getObjectMetadata(bucket,
                             s3ObjSumm.getKey()).getLastModified().getTime() < min) {
                        
-                        store.deleteFromCache(identifier);
+                        getCachingDataStore().deleteFromCache(identifier);
                         LOG.debug("add id [{}] to delete lists",
                             s3ObjSumm.getKey());
                         deleteList.add(new DeleteObjectsRequest.KeyVersion(
@@ -584,9 +581,9 @@ public class S3Backend implements Backend {
     }
 
     @Override
-    public void close() {
+    public void close() throws DataStoreException {
+        super.close();
         // backend is closing. abort all mulitpart uploads from start.
-        asyncWriteExecuter.shutdownNow();
         if(s3service.doesBucketExist(bucket)) {
             tmx.abortMultipartUploads(bucket, startTime);
         }

--- a/jackrabbit-data/src/main/java/org/apache/jackrabbit/core/data/AbstractBackend.java
+++ b/jackrabbit-data/src/main/java/org/apache/jackrabbit/core/data/AbstractBackend.java
@@ -1,0 +1,140 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.jackrabbit.core.data;
+
+import java.util.concurrent.Executor;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ThreadPoolExecutor;
+
+import org.apache.jackrabbit.core.data.util.NamedThreadFactory;
+
+/**
+ * Abstract Backend which has a reference to the underlying {@link CachingDataStore} and is
+ * maintaining the lifecycle of the internal asynchronous write executor.
+ */
+public abstract class AbstractBackend implements Backend {
+
+    /**
+     * {@link CachingDataStore} instance using this backend.
+     */
+    private CachingDataStore cachingDataStore;
+
+    /**
+     * The pool size of asynchronous write pooling executor.
+     */
+    private int asyncWritePoolSize;
+
+    /**
+     * Asynchronous write pooling executor.
+     */
+    private Executor asyncWriteExecutor;
+
+    /**
+     * Returns the pool size of the asynchronous write pool executor.
+     * @return the pool size of the asynchronous write pool executor
+     */
+    public int getAsyncWritePoolSize() {
+        return asyncWritePoolSize;
+    }
+
+    /**
+     * Sets the pool size of the asynchronous write pool executor.
+     * @param asyncWritePoolSize pool size of the async write pool executor
+     */
+    public void setAsyncWritePoolSize(int asyncWritePoolSize) {
+        this.asyncWritePoolSize = asyncWritePoolSize;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void init(CachingDataStore cachingDataStore, String homeDir, String config) throws DataStoreException {
+        this.cachingDataStore = cachingDataStore;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void close() throws DataStoreException {
+        Executor asyncExecutor = getAsyncWriteExecutor();
+
+        if (asyncExecutor != null && asyncExecutor instanceof ExecutorService) {
+            ((ExecutorService) asyncExecutor).shutdownNow();
+        }
+    }
+
+    /**
+     * Returns the {@link CachingDataStore} instance using this backend.
+     * @return the {@link CachingDataStore} instance using this backend
+     */
+    protected CachingDataStore getCachingDataStore() {
+        return cachingDataStore;
+    }
+
+    /**
+     * Sets the {@link CachingDataStore} instance using this backend.
+     * @param cachingDataStore the {@link CachingDataStore} instance using this backend
+     */
+    protected void setCachingDataStore(CachingDataStore cachingDataStore) {
+        this.cachingDataStore = cachingDataStore;
+    }
+
+    /**
+     * Returns Executor used to execute asynchronous write or touch jobs.
+     * @return Executor used to execute asynchronous write or touch jobs
+     */
+    protected Executor getAsyncWriteExecutor() {
+        if (asyncWriteExecutor == null) {
+            asyncWriteExecutor = createAsyncWriteExecutor();
+        }
+
+        return asyncWriteExecutor;
+    }
+
+    /**
+     * Creates an {@link Executor}.
+     * This method is invoked during the initialization for asynchronous write/touch job executions.
+     * @return an {@link Executor}
+     */
+    protected Executor createAsyncWriteExecutor() {
+        Executor asyncExecutor;
+
+        if (getAsyncWritePoolSize() > 0) {
+            asyncExecutor = (ThreadPoolExecutor) Executors.newFixedThreadPool(getAsyncWritePoolSize(),
+                    new NamedThreadFactory(getClass().getSimpleName() + "-write-worker"));
+        } else {
+            asyncExecutor = new ImmediateExecutor();
+        }
+
+        return asyncExecutor;
+    }
+
+    /**
+     * This class implements {@link Executor} interface to run {@code command} right away,
+     * resulting in non-asynchronous mode executions.
+     */
+    private class ImmediateExecutor implements Executor {
+        @Override
+        public void execute(Runnable command) {
+            command.run();
+        }
+    }
+
+}

--- a/jackrabbit-data/src/main/java/org/apache/jackrabbit/core/data/AbstractBackend.java
+++ b/jackrabbit-data/src/main/java/org/apache/jackrabbit/core/data/AbstractBackend.java
@@ -35,6 +35,16 @@ public abstract class AbstractBackend implements Backend {
     private CachingDataStore cachingDataStore;
 
     /**
+     * path of repository home dir.
+     */
+    private String homeDir;
+
+    /**
+     * path of config property file.
+     */
+    private String config;
+
+    /**
      * The pool size of asynchronous write pooling executor.
      */
     private int asyncWritePoolSize;
@@ -66,6 +76,8 @@ public abstract class AbstractBackend implements Backend {
     @Override
     public void init(CachingDataStore cachingDataStore, String homeDir, String config) throws DataStoreException {
         this.cachingDataStore = cachingDataStore;
+        this.homeDir = homeDir;
+        this.config = config;
     }
 
     /**
@@ -94,6 +106,38 @@ public abstract class AbstractBackend implements Backend {
      */
     protected void setCachingDataStore(CachingDataStore cachingDataStore) {
         this.cachingDataStore = cachingDataStore;
+    }
+
+    /**
+     * Returns path of repository home dir.
+     * @return path of repository home dir
+     */
+    protected String getHomeDir() {
+        return homeDir;
+    }
+
+    /**
+     * Sets path of repository home dir.
+     * @param homeDir path of repository home dir
+     */
+    protected void setHomeDir(String homeDir) {
+        this.homeDir = homeDir;
+    }
+
+    /**
+     * Returns path of config property file.
+     * @return path of config property file
+     */
+    protected String getConfig() {
+        return config;
+    }
+
+    /**
+     * Sets path of config property file.
+     * @param config path of config property file
+     */
+    protected void setConfig(String config) {
+        this.config = config;
     }
 
     /**

--- a/jackrabbit-data/src/main/java/org/apache/jackrabbit/core/data/AbstractBackend.java
+++ b/jackrabbit-data/src/main/java/org/apache/jackrabbit/core/data/AbstractBackend.java
@@ -42,7 +42,7 @@ public abstract class AbstractBackend implements Backend {
     /**
      * Asynchronous write pooling executor.
      */
-    private Executor asyncWriteExecutor;
+    private volatile Executor asyncWriteExecutor;
 
     /**
      * Returns the pool size of the asynchronous write pool executor.
@@ -101,11 +101,18 @@ public abstract class AbstractBackend implements Backend {
      * @return Executor used to execute asynchronous write or touch jobs
      */
     protected Executor getAsyncWriteExecutor() {
-        if (asyncWriteExecutor == null) {
-            asyncWriteExecutor = createAsyncWriteExecutor();
+        Executor executor = asyncWriteExecutor;
+
+        if (executor == null) {
+            synchronized (this) {
+                executor = asyncWriteExecutor;
+                if (executor == null) {
+                    asyncWriteExecutor = executor = createAsyncWriteExecutor();
+                }
+            }
         }
 
-        return asyncWriteExecutor;
+        return executor;
     }
 
     /**

--- a/jackrabbit-data/src/main/java/org/apache/jackrabbit/core/data/FSBackend.java
+++ b/jackrabbit-data/src/main/java/org/apache/jackrabbit/core/data/FSBackend.java
@@ -52,6 +52,8 @@ public class FSBackend extends AbstractBackend {
 
     public static final String FS_BACKEND_PATH = "fsBackendPath";
 
+    public static final String ASYNC_WRITE_POOL_SIZE = "asyncWritePoolSize";
+
     /**
      * Logger instance.
      */
@@ -112,6 +114,12 @@ public class FSBackend extends AbstractBackend {
                     + fsPathDir.getAbsolutePath());
             }
         }
+        int asyncWritePoolSize = 10;
+        String value = prop.getProperty(ASYNC_WRITE_POOL_SIZE);
+        if (value != null) {
+            asyncWritePoolSize = Integer.parseInt(value);
+        }
+        setAsyncWritePoolSize(asyncWritePoolSize);
     }
 
     @Override

--- a/jackrabbit-data/src/main/java/org/apache/jackrabbit/core/data/FSBackend.java
+++ b/jackrabbit-data/src/main/java/org/apache/jackrabbit/core/data/FSBackend.java
@@ -32,30 +32,23 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Properties;
 import java.util.Set;
-import java.util.concurrent.Executors;
-import java.util.concurrent.ThreadPoolExecutor;
 
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
-import org.apache.jackrabbit.core.data.util.NamedThreadFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class FSBackend implements Backend {
+public class FSBackend extends AbstractBackend {
 
     private Properties properties;
 
     private String fsPath;
-
-    private CachingDataStore store;
 
     private String homeDir;
 
     private String config;
 
     File fsPathDir;
-
-    private ThreadPoolExecutor asyncWriteExecuter;
 
     public static final String FS_BACKEND_PATH = "fsBackendPath";
 
@@ -70,8 +63,10 @@ public class FSBackend implements Backend {
     private static final int ACCESS_TIME_RESOLUTION = 2000;
 
     @Override
-    public void init(CachingDataStore store, String homeDir, String config)
+    public void init(CachingDataStore cachingDataStore, String homeDir, String config)
                     throws DataStoreException {
+        super.init(cachingDataStore, homeDir, config);
+
         Properties initProps = null;
         // Check is configuration is already provided. That takes precedence
         // over config provided via file based config
@@ -92,13 +87,13 @@ public class FSBackend implements Backend {
             }
             this.properties = initProps;
         }
-        init(store, homeDir, initProps);
+        init(cachingDataStore, homeDir, initProps);
 
     }
 
     public void init(CachingDataStore store, String homeDir, Properties prop)
                     throws DataStoreException {
-        this.store = store;
+        setCachingDataStore(store);
         this.homeDir = homeDir;
         this.fsPath = prop.getProperty(FS_BACKEND_PATH);
         if (this.fsPath == null || "".equals(this.fsPath)) {
@@ -117,9 +112,6 @@ public class FSBackend implements Backend {
                     + fsPathDir.getAbsolutePath());
             }
         }
-        asyncWriteExecuter = (ThreadPoolExecutor) Executors.newFixedThreadPool(
-            10, new NamedThreadFactory("fs-write-worker"));
-
     }
 
     @Override
@@ -190,7 +182,7 @@ public class FSBackend implements Backend {
             throw new IllegalArgumentException(
                 "callback parameter cannot be null in asyncUpload");
         }
-        asyncWriteExecuter.execute(new Runnable() {
+        getAsyncWriteExecutor().execute(new Runnable() {
             @Override
             public void run() {
                 try {
@@ -268,7 +260,7 @@ public class FSBackend implements Backend {
             Thread.currentThread().setContextClassLoader(
                 getClass().getClassLoader());
 
-            asyncWriteExecuter.execute(new Runnable() {
+            getAsyncWriteExecutor().execute(new Runnable() {
                 @Override
                 public void run() {
                     try {
@@ -287,12 +279,6 @@ public class FSBackend implements Backend {
             throw new DataStoreException("Cannot touch the record "
                 + identifier.toString(), e);
         }
-
-    }
-
-    @Override
-    public void close() throws DataStoreException {
-        asyncWriteExecuter.shutdownNow();
 
     }
 
@@ -457,8 +443,8 @@ public class FSBackend implements Backend {
                 }
                 if (lastModified < min) {
                     DataIdentifier id = new DataIdentifier(file.getName());
-                    if (store.confirmDelete(id)) {
-                        store.deleteFromCache(id);
+                    if (getCachingDataStore().confirmDelete(id)) {
+                        getCachingDataStore().deleteFromCache(id);
                         if (LOG.isInfoEnabled()) {
                             LOG.info("Deleting old file "
                                 + file.getAbsolutePath() + " modified: "

--- a/jackrabbit-data/src/main/java/org/apache/jackrabbit/core/data/FSBackend.java
+++ b/jackrabbit-data/src/main/java/org/apache/jackrabbit/core/data/FSBackend.java
@@ -44,10 +44,6 @@ public class FSBackend extends AbstractBackend {
 
     private String fsPath;
 
-    private String homeDir;
-
-    private String config;
-
     File fsPathDir;
 
     public static final String FS_BACKEND_PATH = "fsBackendPath";
@@ -72,7 +68,6 @@ public class FSBackend extends AbstractBackend {
         Properties initProps = null;
         // Check is configuration is already provided. That takes precedence
         // over config provided via file based config
-        this.config = config;
         if (this.properties != null) {
             initProps = this.properties;
         } else {
@@ -96,11 +91,11 @@ public class FSBackend extends AbstractBackend {
     public void init(CachingDataStore store, String homeDir, Properties prop)
                     throws DataStoreException {
         setCachingDataStore(store);
-        this.homeDir = homeDir;
+        setHomeDir(homeDir);
         this.fsPath = prop.getProperty(FS_BACKEND_PATH);
         if (this.fsPath == null || "".equals(this.fsPath)) {
             throw new DataStoreException("Could not initialize FSBackend from "
-                + config + ". [" + FS_BACKEND_PATH + "] property not found.");
+                + getConfig() + ". [" + FS_BACKEND_PATH + "] property not found.");
         }
         fsPathDir = new File(this.fsPath);
         if (fsPathDir.exists() && fsPathDir.isFile()) {

--- a/jackrabbit-data/src/test/java/org/apache/jackrabbit/core/data/InMemoryBackend.java
+++ b/jackrabbit-data/src/test/java/org/apache/jackrabbit/core/data/InMemoryBackend.java
@@ -33,28 +33,20 @@ import java.util.Set;
 /**
  * An in-memory backend implementation used to speed up testing.
  */
-public class InMemoryBackend implements Backend {
+public class InMemoryBackend extends AbstractBackend {
 
     private HashMap<DataIdentifier, byte[]> data = new HashMap<DataIdentifier, byte[]>();
 
     private HashMap<DataIdentifier, Long> timeMap = new HashMap<DataIdentifier, Long>();
-    
-    private CachingDataStore store;
-    
+
     private Properties properties;
 
     @Override
-    public void init(CachingDataStore store, String homeDir, String config)
+    public void init(CachingDataStore cachingDataStore, String homeDir, String config)
             throws DataStoreException {
+        super.init(cachingDataStore, homeDir, config);
         // ignore
         log("init");
-        this.store = store;
-    }
-
-    @Override
-    public void close() {
-        // ignore
-        log("close");
     }
 
     @Override
@@ -110,9 +102,9 @@ public class InMemoryBackend implements Backend {
         for (Map.Entry<DataIdentifier, Long> entry : timeMap.entrySet()) {
             DataIdentifier identifier = entry.getKey();
             long timestamp = entry.getValue();
-            if (timestamp < min && !store.isInUse(identifier)
-                && store.confirmDelete(identifier)) {
-                store.deleteFromCache(identifier);
+            if (timestamp < min && !getCachingDataStore().isInUse(identifier)
+                && getCachingDataStore().confirmDelete(identifier)) {
+                getCachingDataStore().deleteFromCache(identifier);
                 tobeDeleted.add(identifier);
             }
         }

--- a/jackrabbit-data/src/test/java/org/apache/jackrabbit/core/data/TestCachingFDS.java
+++ b/jackrabbit-data/src/test/java/org/apache/jackrabbit/core/data/TestCachingFDS.java
@@ -48,16 +48,12 @@ public class TestCachingFDS extends TestFileDataStore {
         }
         props.setProperty(FSBackend.FS_BACKEND_PATH, fsPath);
         LOG.info("fsBackendPath [{}] set.", fsPath);
+        // disable asynchronous writing in testing.
+        props.setProperty(FSBackend.ASYNC_WRITE_POOL_SIZE, "0");
         cacheFDS.setProperties(props);
         cacheFDS.setSecret("12345");
         cacheFDS.init(dataStoreDir);
         return cacheFDS;
-    }
-
-    @Override
-    protected void doDeleteRecordTest() throws Exception {
-        ds = createDataStore();
-        LOG.info("Skip deleteRecordTest on CachingFDS (JCR-4006)");
     }
 
     /**

--- a/jackrabbit-data/src/test/java/org/apache/jackrabbit/core/data/TestCachingFDSCacheOff.java
+++ b/jackrabbit-data/src/test/java/org/apache/jackrabbit/core/data/TestCachingFDSCacheOff.java
@@ -40,6 +40,8 @@ public class TestCachingFDSCacheOff extends TestFileDataStore {
             fsPath = dataStoreDir + "/cachingFDS";
         }
         props.setProperty(FSBackend.FS_BACKEND_PATH, fsPath);
+        // disable asynchronous writing in testing.
+        props.setProperty(FSBackend.ASYNC_WRITE_POOL_SIZE, "0");
         cacheFDS.setProperties(props);
         cacheFDS.setSecret("12345");
         cacheFDS.setCacheSize(0);

--- a/jackrabbit-vfs-ext/src/main/java/org/apache/jackrabbit/vfs/ext/ds/VFSDataStore.java
+++ b/jackrabbit-vfs-ext/src/main/java/org/apache/jackrabbit/vfs/ext/ds/VFSDataStore.java
@@ -111,7 +111,7 @@ public class VFSDataStore extends CachingDataStore {
     /**
      * The pool size of asynchronous write pooling executor.
      */
-    private int asyncWritePoolSize = VFSBackend.DEFAULT_ASYNC_WRITE_POOL_SIZE;
+    private int asyncWritePoolSize = 10;
 
     @Override
     public void init(String homeDir) throws RepositoryException {


### PR DESCRIPTION
- Add AbstractBackend.java that maintains the lifecycle of async writer executor and initializes ImmediateExecutor when asyncWritePoolSize is 0 or smaller.
- Change Backend implementations to extends AbstractBackend, so that each can have an option to disable asynchronous writing.
- Change TestCachingFDS to disable asynchronous writing in unit test.
- Keep the current async writer pool size as-is for the others (for backward compatibility).
