### PR TITLE
JCR-4073: wait until the purgin thread completes.

### DIFF
--- a/jackrabbit-data/src/test/java/org/apache/jackrabbit/core/data/TestLocalCache.java
+++ b/jackrabbit-data/src/test/java/org/apache/jackrabbit/core/data/TestLocalCache.java
@@ -191,7 +191,10 @@ public class TestLocalCache extends TestCase {
             byteMap.put("a4", data);
             // storing a4 should purge cache
             cache.store("a4", new ByteArrayInputStream(byteMap.get("a4")));
-            Thread.sleep(1000);
+            // because purging is done by an asynchronous thread, let's wait until purging done.
+            do {
+                Thread.sleep(1000);
+            } while (cache.isInPurgeMode());
 
             result = cache.getIfStored("a1");
             assertNull("a1 should be null", result);


### PR DESCRIPTION
Just happened to see this ticket. I guess it was caused by the fact that the purging is done in an asynchronous thread and occasionally there might have been a timing issue as Amit already pointed out in the ticket.
Perhaps my pull request will fix this problem.