### PR TITLE
JCR-4536: Feature/enable insecure https host

### DIFF
--- a/jackrabbit-spi2dav/src/main/java/org/apache/jackrabbit/spi2dav/RepositoryServiceImpl.java
+++ b/jackrabbit-spi2dav/src/main/java/org/apache/jackrabbit/spi2dav/RepositoryServiceImpl.java
@@ -521,7 +521,7 @@ public class RepositoryServiceImpl implements RepositoryService, DavConstants {
      * SessionInfo or a marker if the session info is null (used during
      * repository instantiation).
      *
-     * @param sessionInfo
+     * @param sessionInfo the session info to check.
      * @return Key for the client map.
      */
     private static Object getClientKey(SessionInfo sessionInfo) {
@@ -577,7 +577,7 @@ public class RepositoryServiceImpl implements RepositoryService, DavConstants {
      * Clear all URI mappings. This is required after hierarchy operations such
      * as e.g. MOVE.
      *
-     * @param sessionInfo
+     * @param sessionInfo the session info to check.
      */
     protected void clearItemUriCache(SessionInfo sessionInfo) {
         uriResolver.clearCacheEntries(sessionInfo);
@@ -645,6 +645,8 @@ public class RepositoryServiceImpl implements RepositoryService, DavConstants {
     //--------------------------------------------------------------------------
     /**
      * Execute a 'Workspace' operation.
+     * @param request HTTP request.
+     * @param sessionInfo the session info to check.
      */
     private HttpResponse execute(BaseDavRequest request, SessionInfo sessionInfo) throws RepositoryException {
         try {
@@ -1040,9 +1042,9 @@ public class RepositoryServiceImpl implements RepositoryService, DavConstants {
     }
 
     /**
-     *
-     * @param sessionInfo
-     * @param itemId
+     * get item definion from session.
+     * @param sessionInfo the session info to check.
+     * @param itemId cache item id
      * @return
      * @throws RepositoryException
      */
@@ -2632,7 +2634,7 @@ public class RepositoryServiceImpl implements RepositoryService, DavConstants {
 
     /**
      *
-     * @param sessionInfo
+     * @param sessionInfo the session info to check.
      * @param namespaces
      * @throws NamespaceException
      * @throws UnsupportedRepositoryOperationException
@@ -2784,8 +2786,10 @@ public class RepositoryServiceImpl implements RepositoryService, DavConstants {
     }
 
     /**
-     * Compute the repository URI (while dealing with trailing / and port number
-     * defaulting)
+     * Compute the repository URI (while dealing with trailing / and port number defaulting).
+     * @param uri uri to use
+     * @return repository uri
+     * @throws URISyntaxException if cant compute uri
      */
     public static URI computeRepositoryUri(String uri) throws URISyntaxException {
         URI repositoryUri = URI.create((uri.endsWith("/")) ? uri : uri + "/");
@@ -2808,10 +2812,10 @@ public class RepositoryServiceImpl implements RepositoryService, DavConstants {
     }
 
     /**
-     *
-     * @param sessionInfo
-     * @param reportDoc
-     * @return
+     * Get node type definition from element.
+     * @param sessionInfo the session info to check.
+     * @param reportDoc root element to use.
+     * @return found node type
      * @throws RepositoryException
      */
     private Iterator<QNodeTypeDefinition> retrieveQNodeTypeDefinitions(SessionInfo sessionInfo, Document reportDoc) throws RepositoryException {

--- a/jackrabbit-spi2dav/src/main/java/org/apache/jackrabbit/spi2dav/RepositoryServiceImpl.java
+++ b/jackrabbit-spi2dav/src/main/java/org/apache/jackrabbit/spi2dav/RepositoryServiceImpl.java
@@ -270,10 +270,11 @@ public class RepositoryServiceImpl implements RepositoryService, DavConstants {
     private Set<String> remoteDavComplianceClasses = null;
 
     /**
-     * Same as {@link #RepositoryServiceImpl(String, IdFactory, NameFactory, PathFactory, QValueFactory, int, int)}
+     * Same as {@link #RepositoryServiceImpl(String, IdFactory, NameFactory, PathFactory, QValueFactory, int, int, boolean)}
      * using {@link ItemInfoCacheImpl#DEFAULT_CACHE_SIZE} as size for the item
      * cache and {@link #MAX_CONNECTIONS_DEFAULT} for the maximum number of
-     * connections on the client.
+     * connections on the client and FALSE for allowInsecureHttps for
+     * connection to host that has custom certificate.
      *
      * @param uri The server uri.
      * @param idFactory The id factory.
@@ -285,13 +286,12 @@ public class RepositoryServiceImpl implements RepositoryService, DavConstants {
     public RepositoryServiceImpl(String uri, IdFactory idFactory,
                                  NameFactory nameFactory, PathFactory pathFactory,
                                  QValueFactory qValueFactory) throws RepositoryException {
-        this(uri, idFactory, nameFactory, pathFactory, qValueFactory, MAX_CONNECTIONS_DEFAULT, false);
+        this(uri, idFactory, nameFactory, pathFactory, qValueFactory, ItemInfoCacheImpl.DEFAULT_CACHE_SIZE);
     }
 
     /**
-     * Same as {@link #RepositoryServiceImpl(String, IdFactory, NameFactory, PathFactory, QValueFactory, int, int)}
-     * using {@link ItemInfoCacheImpl#DEFAULT_CACHE_SIZE} as size for the item
-     * cache and {@link #MAX_CONNECTIONS_DEFAULT} for the maximum number of
+     * Same as {@link #RepositoryServiceImpl(String, IdFactory, NameFactory, PathFactory, QValueFactory, int, int, boolean)}
+     * using {@link #MAX_CONNECTIONS_DEFAULT} for the maximum number of
      * connections on the client.
      *
      * @param uri The server uri.
@@ -310,10 +310,11 @@ public class RepositoryServiceImpl implements RepositoryService, DavConstants {
     }
 
     /**
-     * Same as {@link #RepositoryServiceImpl(String, IdFactory, NameFactory, PathFactory, QValueFactory, int, int)}
+     * Same as {@link #RepositoryServiceImpl(String, IdFactory, NameFactory, PathFactory, QValueFactory, int, int, boolean)}
      * using {@link ItemInfoCacheImpl#DEFAULT_CACHE_SIZE} as size for the item
      * cache and {@link #MAX_CONNECTIONS_DEFAULT} for the maximum number of
-     * connections on the client.
+     * connections on the client and FALSE for allowInsecureHttps for
+     * connection to host that has custom certificate.
      *
      * @param uri The server uri.
      * @param idFactory The id factory.
@@ -332,9 +333,10 @@ public class RepositoryServiceImpl implements RepositoryService, DavConstants {
     }
 
     /**
-     * Same as {@link #RepositoryServiceImpl(String, IdFactory, NameFactory, PathFactory, QValueFactory, int, int)}
+     * Same as {@link #RepositoryServiceImpl(String, IdFactory, NameFactory, PathFactory, QValueFactory, int, int, boolean)}
      * using {@link #MAX_CONNECTIONS_DEFAULT} for the maximum number of
-     * connections on the client.
+     * connections on the client and FALSE for allowInsecureHttps for
+     * connection to host that has custom certificate.
      *
      * @param uri The server uri.
      * @param idFactory The id factory.
@@ -347,7 +349,7 @@ public class RepositoryServiceImpl implements RepositoryService, DavConstants {
     public RepositoryServiceImpl(String uri, IdFactory idFactory,
                                  NameFactory nameFactory, PathFactory pathFactory,
                                  QValueFactory qValueFactory, int itemInfoCacheSize) throws RepositoryException {
-        this(uri, idFactory, nameFactory, pathFactory, qValueFactory, itemInfoCacheSize, MAX_CONNECTIONS_DEFAULT);
+        this(uri, idFactory, nameFactory, pathFactory, qValueFactory, itemInfoCacheSize, MAX_CONNECTIONS_DEFAULT, false);
     }
 
     /**

--- a/jackrabbit-spi2dav/src/main/java/org/apache/jackrabbit/spi2dav/RepositoryServiceImpl.java
+++ b/jackrabbit-spi2dav/src/main/java/org/apache/jackrabbit/spi2dav/RepositoryServiceImpl.java
@@ -288,12 +288,43 @@ public class RepositoryServiceImpl implements RepositoryService, DavConstants {
         this(uri, idFactory, nameFactory, pathFactory, qValueFactory, MAX_CONNECTIONS_DEFAULT, false);
     }
 
+    /**
+     * Same as {@link #RepositoryServiceImpl(String, IdFactory, NameFactory, PathFactory, QValueFactory, int, int)}
+     * using {@link ItemInfoCacheImpl#DEFAULT_CACHE_SIZE} as size for the item
+     * cache and {@link #MAX_CONNECTIONS_DEFAULT} for the maximum number of
+     * connections on the client.
+     *
+     * @param uri The server uri.
+     * @param idFactory The id factory.
+     * @param nameFactory The name factory.
+     * @param pathFactory The path factory.
+     * @param qValueFactory The value factory.
+     * @param itemInfoCacheSize The size of the item info cache.
+     * @param allowInsecureHttps Allow connecting to repository with custom certificate.
+     * @throws RepositoryException If an error occurs.
+     */
     public RepositoryServiceImpl(String uri, IdFactory idFactory,
                                  NameFactory nameFactory, PathFactory pathFactory,
                                  QValueFactory qValueFactory, int itemInfoCacheSize, boolean allowInsecureHttps) throws RepositoryException {
         this(uri, idFactory, nameFactory, pathFactory, qValueFactory, itemInfoCacheSize, MAX_CONNECTIONS_DEFAULT, allowInsecureHttps);
     }
 
+    /**
+     * Same as {@link #RepositoryServiceImpl(String, IdFactory, NameFactory, PathFactory, QValueFactory, int, int)}
+     * using {@link ItemInfoCacheImpl#DEFAULT_CACHE_SIZE} as size for the item
+     * cache and {@link #MAX_CONNECTIONS_DEFAULT} for the maximum number of
+     * connections on the client.
+     *
+     * @param uri The server uri.
+     * @param idFactory The id factory.
+     * @param nameFactory The name factory.
+     * @param pathFactory The path factory.
+     * @param qValueFactory The value factory.
+     * @param itemInfoCacheSize The size of the item info cache.
+     * @param maximumHttpConnections A int &gt;0 defining the maximum number of
+     * connections per host to be configured on
+     * @throws RepositoryException If an error occurs.
+     */
     public RepositoryServiceImpl(String uri, IdFactory idFactory,
                                  NameFactory nameFactory, PathFactory pathFactory,
                                  QValueFactory qValueFactory, int itemInfoCacheSize, int maximumHttpConnections ) throws RepositoryException {
@@ -330,6 +361,7 @@ public class RepositoryServiceImpl implements RepositoryService, DavConstants {
      * @param itemInfoCacheSize The size of the item info cache.
      * @param maximumHttpConnections A int &gt;0 defining the maximum number of
      * connections per host to be configured on
+     * @param allowInsecureHttps Allow connecting to repository with custom certificate.
      * {@link PoolingHttpClientConnectionManager#setMaxTotal(int)}.
      * @throws RepositoryException If an error occurs.
      */
@@ -1099,9 +1131,9 @@ public class RepositoryServiceImpl implements RepositoryService, DavConstants {
     /**
      * get item definion from session.
      * @param sessionInfo the session info to check.
-     * @param itemId cache item id
-     * @return
-     * @throws RepositoryException
+     * @param itemId cache item id.
+     * @return item definition
+     * @throws RepositoryException if cant get item uri.
      */
     private QItemDefinition getItemDefinition(SessionInfo sessionInfo, ItemId itemId) throws RepositoryException {
         // set of properties to be retrieved

--- a/jackrabbit-spi2dav/src/main/java/org/apache/jackrabbit/spi2davex/BatchReadConfig.java
+++ b/jackrabbit-spi2dav/src/main/java/org/apache/jackrabbit/spi2davex/BatchReadConfig.java
@@ -31,12 +31,13 @@ public interface BatchReadConfig {
     /**
      * Return the depth for the given path.
      *
-     * @param path
-     * @param resolver
+     * @param path path to yse
+     * @param resolver resolver to use
      * @return -1 if all child infos should be return or any value greater
      * than -1 if only parts of the subtree should be returned. If there is no
      * matching configuration entry some implementation specific default depth
      * will be returned.
+     * @throws NamespaceException if cant read value
      */
     public int getDepth(Path path, PathResolver resolver) throws NamespaceException;
 

--- a/jackrabbit-spi2dav/src/main/java/org/apache/jackrabbit/spi2davex/ItemInfoImpl.java
+++ b/jackrabbit-spi2dav/src/main/java/org/apache/jackrabbit/spi2davex/ItemInfoImpl.java
@@ -44,7 +44,7 @@ public abstract class ItemInfoImpl implements ItemInfo, Serializable {
      *
      * @param path     the path to this item.
      * @param isNode   if this item is a node.
-     * @throws javax.jcr.RepositoryException if path is null
+     * @throws javax.jcr.RepositoryException if path is null.
      */
     public ItemInfoImpl(Path path, boolean isNode) throws RepositoryException {
         if (path == null) {

--- a/jackrabbit-spi2dav/src/main/java/org/apache/jackrabbit/spi2davex/ItemInfoImpl.java
+++ b/jackrabbit-spi2dav/src/main/java/org/apache/jackrabbit/spi2davex/ItemInfoImpl.java
@@ -44,7 +44,7 @@ public abstract class ItemInfoImpl implements ItemInfo, Serializable {
      *
      * @param path     the path to this item.
      * @param isNode   if this item is a node.
-     * @throws javax.jcr.RepositoryException
+     * @throws javax.jcr.RepositoryException if path is null
      */
     public ItemInfoImpl(Path path, boolean isNode) throws RepositoryException {
         if (path == null) {

--- a/jackrabbit-spi2dav/src/main/java/org/apache/jackrabbit/spi2davex/RepositoryServiceImpl.java
+++ b/jackrabbit-spi2dav/src/main/java/org/apache/jackrabbit/spi2davex/RepositoryServiceImpl.java
@@ -159,7 +159,7 @@ public class RepositoryServiceImpl extends org.apache.jackrabbit.spi2dav.Reposit
      * @throws RepositoryException If an exception occurs.
      */
     public RepositoryServiceImpl(String jcrServerURI, BatchReadConfig batchReadConfig) throws RepositoryException {
-        this(jcrServerURI, null, batchReadConfig, ItemInfoCacheImpl.DEFAULT_CACHE_SIZE);
+        this(jcrServerURI, null, batchReadConfig, ItemInfoCacheImpl.DEFAULT_CACHE_SIZE, false);
     }
 
     /**
@@ -174,9 +174,8 @@ public class RepositoryServiceImpl extends org.apache.jackrabbit.spi2dav.Reposit
      * @throws RepositoryException If an exception occurs.
      */
     public RepositoryServiceImpl(String jcrServerURI, String defaultWorkspaceName,
-                                 BatchReadConfig batchReadConfig, int itemInfoCacheSize) throws RepositoryException {
-        this(jcrServerURI, defaultWorkspaceName, batchReadConfig, itemInfoCacheSize, MAX_CONNECTIONS_DEFAULT);
-    }
+                                 BatchReadConfig batchReadConfig, int itemInfoCacheSize, Boolean allowInsecureHttps) throws RepositoryException {
+        this(jcrServerURI, defaultWorkspaceName, batchReadConfig, itemInfoCacheSize, MAX_CONNECTIONS_DEFAULT, allowInsecureHttps);    }
 
     /**
      * Creates a new instance of this repository service.
@@ -192,10 +191,10 @@ public class RepositoryServiceImpl extends org.apache.jackrabbit.spi2dav.Reposit
      */
     public RepositoryServiceImpl(String jcrServerURI, String defaultWorkspaceName,
                                  BatchReadConfig batchReadConfig, int itemInfoCacheSize,
-                                 int maximumHttpConnections) throws RepositoryException {
+                                 int maximumHttpConnections, boolean allowInsecureHttps) throws RepositoryException {
 
         super(jcrServerURI, IdFactoryImpl.getInstance(), NameFactoryImpl.getInstance(),
-                PathFactoryImpl.getInstance(), new QValueFactoryImpl(), itemInfoCacheSize, maximumHttpConnections);
+                PathFactoryImpl.getInstance(), new QValueFactoryImpl(), itemInfoCacheSize, maximumHttpConnections, allowInsecureHttps);
 
         try {
             URI repositoryUri = computeRepositoryUri(jcrServerURI);

--- a/jackrabbit-spi2dav/src/main/java/org/apache/jackrabbit/spi2davex/RepositoryServiceImpl.java
+++ b/jackrabbit-spi2dav/src/main/java/org/apache/jackrabbit/spi2davex/RepositoryServiceImpl.java
@@ -171,11 +171,32 @@ public class RepositoryServiceImpl extends org.apache.jackrabbit.spi2dav.Reposit
      * @param defaultWorkspaceName The default workspace name.
      * @param batchReadConfig The batch read configuration.
      * @param itemInfoCacheSize The size of the item info cache.
+     * @param allowInsecureHttps Allow connecting to repository with custom certificate.
      * @throws RepositoryException If an exception occurs.
      */
     public RepositoryServiceImpl(String jcrServerURI, String defaultWorkspaceName,
                                  BatchReadConfig batchReadConfig, int itemInfoCacheSize, Boolean allowInsecureHttps) throws RepositoryException {
-        this(jcrServerURI, defaultWorkspaceName, batchReadConfig, itemInfoCacheSize, MAX_CONNECTIONS_DEFAULT, allowInsecureHttps);    }
+        this(jcrServerURI, defaultWorkspaceName, batchReadConfig, itemInfoCacheSize, MAX_CONNECTIONS_DEFAULT, allowInsecureHttps);
+    }
+
+    /**
+     * Same as {@link #RepositoryServiceImpl(String, String, BatchReadConfig, int, int, boolean)}
+     * using <code>false</code> for allowInsecureHttps.
+     *
+     * @param jcrServerURI The server uri.
+     * @param defaultWorkspaceName The default workspace name.
+     * @param batchReadConfig The batch read configuration.
+     * @param itemInfoCacheSize The size of the item info cache.
+     * @param maximumHttpConnections maximumHttpConnections A int &gt;0 defining
+     * the maximum number of connections per host to be configured on
+     * {@link org.apache.http.impl.conn.PoolingHttpClientConnectionManager#setDefaultMaxPerRoute(int)}.
+     * @throws RepositoryException If an exception occurs.
+     */
+    public RepositoryServiceImpl(String jcrServerURI, String defaultWorkspaceName,
+                                 BatchReadConfig batchReadConfig, int itemInfoCacheSize,
+                                 int maximumHttpConnections) throws RepositoryException {
+        this(jcrServerURI, defaultWorkspaceName, batchReadConfig, itemInfoCacheSize, maximumHttpConnections, false);
+    }
 
     /**
      * Creates a new instance of this repository service.
@@ -185,6 +206,7 @@ public class RepositoryServiceImpl extends org.apache.jackrabbit.spi2dav.Reposit
      * @param batchReadConfig The batch read configuration.
      * @param itemInfoCacheSize The size of the item info cache.
      * @param maximumHttpConnections maximumHttpConnections A int &gt;0 defining
+     * @param allowInsecureHttps Allow connecting to repository with custom certificate.
      * the maximum number of connections per host to be configured on
      * {@link org.apache.http.impl.conn.PoolingHttpClientConnectionManager#setDefaultMaxPerRoute(int)}.
      * @throws RepositoryException If an exception occurs.

--- a/jackrabbit-spi2dav/src/main/java/org/apache/jackrabbit/spi2davex/Spi2davexRepositoryServiceFactory.java
+++ b/jackrabbit-spi2dav/src/main/java/org/apache/jackrabbit/spi2davex/Spi2davexRepositoryServiceFactory.java
@@ -41,6 +41,12 @@ public class Spi2davexRepositoryServiceFactory implements RepositoryServiceFacto
     public static final String PARAM_REPOSITORY_URI = "org.apache.jackrabbit.spi2davex.uri";
 
     /**
+     * Optional configuration parameter to allow access to servers with invalid ssl certs.
+     * Similar to curls --insecure option.
+     */
+    public static final String PARAM_REPOSITORY_URI_INSECURE = "org.apache.jackrabbit.spi2davex.uri.insecure";
+
+    /**
      * Default URI for the {@link #PARAM_REPOSITORY_URI} configuration
      * parameter.
      */
@@ -95,6 +101,7 @@ public class Spi2davexRepositoryServiceFactory implements RepositoryServiceFacto
         // since JCR-4120 the default workspace name is no longer set to 'default'
         // note: if running with JCR Server < 1.5 a default workspace name must therefore be configured
         String workspaceNameDefault = null;
+        boolean allowInsecureHttps = false; //default to false
 
         if (parameters != null) {
             // batchRead config
@@ -127,12 +134,17 @@ public class Spi2davexRepositoryServiceFactory implements RepositoryServiceFacto
             if (param != null) {
                 workspaceNameDefault = param.toString();
             }
+
+            param = parameters.get(PARAM_REPOSITORY_URI_INSECURE);
+            if (param != null) {
+                allowInsecureHttps = Boolean.valueOf(param.toString());
+            }
         }
 
         if (maximumHttpConnections > 0) {
-            return new RepositoryServiceImpl(uri, workspaceNameDefault, brc, itemInfoCacheSize, maximumHttpConnections);
+            return new RepositoryServiceImpl(uri, workspaceNameDefault, brc, itemInfoCacheSize, maximumHttpConnections, allowInsecureHttps);
         } else {
-            return new RepositoryServiceImpl(uri, workspaceNameDefault, brc, itemInfoCacheSize);
+            return new RepositoryServiceImpl(uri, workspaceNameDefault, brc, itemInfoCacheSize, allowInsecureHttps);
         }
     }
 


### PR DESCRIPTION
Adding support for insecure parameter to allow access to https with invalid certs.

Enabling optional support for expired ssl certs when using https on development server with self generated certificates.