### PR TITLE
clarify javadoc of NamespaceResolver.getPrefix() to make it clear that

### DIFF
--- a/jackrabbit-spi-commons/src/main/java/org/apache/jackrabbit/spi/commons/conversion/NameParser.java
+++ b/jackrabbit-spi-commons/src/main/java/org/apache/jackrabbit/spi/commons/conversion/NameParser.java
@@ -44,7 +44,7 @@ public class NameParser {
      * @param jcrName the name to be parsed. The jcrName may either be in the
      * qualified or in the expanded form.
      * @param resolver <code>NamespaceResolver</code> use to retrieve the
-     * namespace URI from the prefix contained in the given JCR name.
+     * namespace URI from the prefix contained in the given JCR name. Must resolve the empty prefix "" as well.
      * @return qName the new <code>Name</code>
      * @throws IllegalNameException If <code>jcrName</code> is not a valid
      * JCR-style name.

--- a/jackrabbit-spi-commons/src/main/java/org/apache/jackrabbit/spi/commons/namespace/NamespaceResolver.java
+++ b/jackrabbit-spi-commons/src/main/java/org/apache/jackrabbit/spi/commons/namespace/NamespaceResolver.java
@@ -18,6 +18,8 @@ package org.apache.jackrabbit.spi.commons.namespace;
 
 import javax.jcr.NamespaceException;
 
+import org.apache.jackrabbit.spi.commons.conversion.NameParser;
+
 /**
  * Interface for resolving namespace URIs and prefixes. Unlike the JCR
  * {@link javax.jcr.NamespaceRegistry} interface, this interface contains
@@ -30,9 +32,10 @@ public interface NamespaceResolver {
 
     /**
      * Returns the URI to which the given prefix is mapped.
+     * For the empty prefix the default namespace uri should be returned as the {@link NameParser} relies on that.
      *
      * @param prefix namespace prefix
-     * @return the namespace URI to which the given prefix is mapped.
+     * @return the namespace URI to which the given prefix is mapped (never {@code null}).
      * @throws NamespaceException if the prefix is unknown.
      */
     String getURI(String prefix) throws NamespaceException;
@@ -41,7 +44,7 @@ public interface NamespaceResolver {
      * Returns the prefix which is mapped to the given URI.
      *
      * @param uri namespace URI
-     * @return the prefix mapped to the given URI.
+     * @return the prefix mapped to the given URI (never {@code null}).
      * @throws NamespaceException if the URI is unknown.
      */
     String getPrefix(String uri) throws NamespaceException;


### PR DESCRIPTION
this is supposed to resolve the empty prefix as well

In addition clarify that returning null is not allowed.