### PR TITLE
JCR-3928: Add pathStyleAccess flag

### DIFF
--- a/jackrabbit-aws-ext/src/main/java/org/apache/jackrabbit/aws/ext/S3Constants.java
+++ b/jackrabbit-aws-ext/src/main/java/org/apache/jackrabbit/aws/ext/S3Constants.java
@@ -108,6 +108,11 @@ public final class S3Constants {
     public static final String PROXY_PORT = "proxyPort";
 
     /**
+     * Path style access flag true/false
+     */
+    public static final String S3_PATH_STYLE_ACCESS = "pathStyleAccess";
+
+    /**
      * private constructor so that class cannot initialized from outside.
      */
     private S3Constants() {

--- a/jackrabbit-aws-ext/src/main/java/org/apache/jackrabbit/aws/ext/Utils.java
+++ b/jackrabbit-aws-ext/src/main/java/org/apache/jackrabbit/aws/ext/Utils.java
@@ -34,6 +34,7 @@ import com.amazonaws.auth.BasicAWSCredentials;
 import com.amazonaws.regions.Regions;
 import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.AmazonS3Client;
+import com.amazonaws.services.s3.S3ClientOptions;
 import com.amazonaws.services.s3.model.ObjectListing;
 import com.amazonaws.services.s3.model.Region;
 import com.amazonaws.services.s3.model.S3ObjectSummary;
@@ -126,6 +127,7 @@ public final class Utils {
          */
         s3service.setEndpoint(endpoint);
         LOG.info("S3 service endpoint [{}] ", endpoint);
+        s3service.setS3ClientOptions(getS3ClientOptions(prop));
         return s3service;
     }
 
@@ -222,6 +224,11 @@ public final class Utils {
         cc.setMaxErrorRetry(maxErrorRetry);
         
         return cc;
+    }
+
+    private static S3ClientOptions getS3ClientOptions(Properties prop) {
+        boolean pathStyleAccess = Boolean.parseBoolean(prop.getProperty(S3Constants.S3_PATH_STYLE_ACCESS));
+        return S3ClientOptions.builder().setPathStyleAccess(pathStyleAccess).build();
     }
 
 }


### PR DESCRIPTION
Based on #47 but without the deprecations and lots of random commits.

This will resolve [JCR-3928](https://issues.apache.org/jira/browse/JCR-3928).

This capability is required because our on premise S3 solutions uses path style.