### PR TITLE
JCR-4935 skip invalid xml characters in session.exportDocumentView()

### DIFF
--- a/jackrabbit-core/src/test/java/org/apache/jackrabbit/core/xml/DocumentViewTest.java
+++ b/jackrabbit-core/src/test/java/org/apache/jackrabbit/core/xml/DocumentViewTest.java
@@ -154,13 +154,13 @@ public class DocumentViewTest extends AbstractJCRTest {
                 ImportUUIDBehavior.IMPORT_UUID_COLLISION_THROW);
 
         node = root.getNode("invalid-xml-character-test");
-        assertEquals("", node.getProperty("0x3").getString());
-        assertEquals("", node.getProperty("0xB").getString());
-        assertEquals("", node.getProperty("0xC").getString());
-        assertEquals("", node.getProperty("0x19").getString());
-        assertEquals("", node.getProperty("0xD800").getString());
-        assertEquals("", node.getProperty("0xFFFE").getString());
-        assertEquals("", node.getProperty("0xD800").getString());
+        assertEquals("\\u0003", node.getProperty("0x3").getString());
+        assertEquals("\\u000b", node.getProperty("0xB").getString());
+        assertEquals("\\u000c", node.getProperty("0xC").getString());
+        assertEquals("\\u0019", node.getProperty("0x19").getString());
+        assertEquals("\\ud800", node.getProperty("0xD800").getString());
+        assertEquals("\\ufffe", node.getProperty("0xFFFE").getString());
+        assertEquals("\\ud800", node.getProperty("0xD800").getString());
     }
 
 

--- a/jackrabbit-jcr-commons/src/main/java/org/apache/jackrabbit/commons/xml/ToXmlContentHandler.java
+++ b/jackrabbit-jcr-commons/src/main/java/org/apache/jackrabbit/commons/xml/ToXmlContentHandler.java
@@ -24,6 +24,7 @@ import java.io.UnsupportedEncodingException;
 import java.io.Writer;
 import java.nio.charset.StandardCharsets;
 
+import org.apache.jackrabbit.util.XMLChar;
 import org.xml.sax.Attributes;
 import org.xml.sax.ContentHandler;
 import org.xml.sax.SAXException;
@@ -139,7 +140,7 @@ public class ToXmlContentHandler extends DefaultHandler {
                     writer.write("&quot;");
                 } else if (attribute && ch[i] == '\'') {
                     writer.write("&apos;");
-                } else {
+                } else if (XMLChar.isValid(ch[i])){
                     writer.write(ch[i]);
                 }
             } catch (IOException e) {
@@ -275,5 +276,4 @@ public class ToXmlContentHandler extends DefaultHandler {
     public String toString() {
         return writer.toString();
     }
-
 }


### PR DESCRIPTION
Addresses https://issues.apache.org/jira/browse/JCR-4935