### PR TITLE
Added automatic module definition for JPMS compatibility

### DIFF
--- a/jackrabbit-webdav/pom.xml
+++ b/jackrabbit-webdav/pom.xml
@@ -40,6 +40,11 @@
         <groupId>org.apache.felix</groupId>
         <artifactId>maven-bundle-plugin</artifactId>
         <extensions>true</extensions>
+        <configuration>
+          <instructions>
+            <Automatic-Module-Name>jackrabbit.webdav</Automatic-Module-Name>
+          </instructions>
+        </configuration>
       </plugin>
       <plugin>
         <artifactId>maven-surefire-plugin</artifactId>


### PR DESCRIPTION
Currently Jackrabbit JARs have no support for the Java Platform Module System. This change provides an example of minimal support.