### PR TITLE
Added pause/resume sync to ClusterNode

### DIFF
--- a/jackrabbit-core/src/main/java/org/apache/jackrabbit/core/cluster/ClusterNode.java
+++ b/jackrabbit-core/src/main/java/org/apache/jackrabbit/core/cluster/ClusterNode.java
@@ -394,6 +394,41 @@ public class ClusterNode implements Runnable,
     }
 
     /**
+     * Pauses sync on the cluster node.
+     */
+    public synchronized void pauseSync() throws ClusterException {
+        try {
+            syncLock.acquire();
+        } catch (InterruptedException e) {
+            String msg = "Interrupted while waiting for mutex.";
+            throw new ClusterException(msg);
+        }
+    }
+
+    /**
+     * Attempts to pause sync on the cluster node waiting up to the provided msecs.
+     * @see EDU.oswego.cs.dl.util.concurrent.Mutex#attempt(long)
+     * @param msecs Number of milliseconds to wait
+     * @return True of lock was acquired, otherwise false
+     * @throws ClusterException
+     */
+    public synchronized boolean pauseSync(long msecs) throws ClusterException {
+        try {
+            return syncLock.attempt(msecs);
+        } catch (InterruptedException e) {
+            String msg = "Interrupted while waiting for mutex.";
+            throw new ClusterException(msg);
+        }
+    }
+
+    /**
+     * Resumes sync the cluster node.
+     */
+    public synchronized void resumeSync() {
+        syncLock.release();
+    }
+
+    /**
      * Create an {@link UpdateEventChannel} for some workspace.
      *
      * @param workspace workspace name


### PR DESCRIPTION
This PR adds three methods to `ClusterNode`:

1. `ClusterNode#pauseSync()` acquires the `syncLock` to prevent any new synchronizations from running. If synchronization is currently running or the lock is otherwise acquired by another thread this one will wait indefinitely or throw a `ClusterException` if the thread is interrupted.
2. `ClusterNode#pauseSync(long)` does the same as #1 but only waits the specified number of milliseconds to acquire the lock and returns true if the lock was acquired, otherwise false.
3. `ClusterNode#resumeSync()` releases the lock allowing the normal synchronization process to resume.

One use case for this is performing a hot backup of a running node. We can pause synchronization to ensure this node does not try to update the index while we perform our backup action. Note this only handles updates coming into the cluster from other nodes -- you'd still have to make sure the local node isn't performing any of its own content/index updates. Incomplete in that regard but gets us part way there.

See https://issues.apache.org/jira/browse/JCR-5142