### PR TITLE
Exposed the existing "disableAutoSync" property of ClusterNode to external configuration.

### DIFF
--- a/jackrabbit-core/src/main/java/org/apache/jackrabbit/core/cluster/ClusterNode.java
+++ b/jackrabbit-core/src/main/java/org/apache/jackrabbit/core/cluster/ClusterNode.java
@@ -225,6 +225,7 @@ public class ClusterNode implements Runnable,
         clusterNodeId = cc.getId();
         syncDelay = cc.getSyncDelay();
         stopDelay = cc.getStopDelay();
+        disableAutoSync = cc.isDisableAutoSync();
 
         try {
             journal = cc.getJournal(clusterContext.getNamespaceResolver());

--- a/jackrabbit-core/src/main/java/org/apache/jackrabbit/core/config/ClusterConfig.java
+++ b/jackrabbit-core/src/main/java/org/apache/jackrabbit/core/config/ClusterConfig.java
@@ -48,6 +48,11 @@ public class ClusterConfig implements JournalFactory {
     private final JournalFactory jf;
 
     /**
+     * Disable auto sync
+     */
+    private final boolean disableAutoSync;
+
+    /**
      * Creates a new cluster configuration.
      *
      * @param id custom cluster node id
@@ -68,10 +73,26 @@ public class ClusterConfig implements JournalFactory {
      */
     public ClusterConfig(String id, long syncDelay,
                          long stopDelay, JournalFactory jf) {
+        this (id, syncDelay, stopDelay, jf, false);
+    }
+
+    /**
+     * Creates a new cluster configuration.
+     *
+     * @param id custom cluster node id
+     * @param syncDelay syncDelay, in milliseconds
+     * @param stopDelay stopDelay in milliseconds
+     * @param jf journal factory
+     * @param disableAutoSync trye if auto sync is disabled
+     */
+    public ClusterConfig(String id, long syncDelay,
+                         long stopDelay, JournalFactory jf,
+                         boolean disableAutoSync) {
         this.id = id;
         this.syncDelay = syncDelay;
         this.stopDelay = stopDelay < 0 ? syncDelay * 10 : stopDelay;
         this.jf = jf;
+        this.disableAutoSync = disableAutoSync;
     }
 
     /**
@@ -112,4 +133,10 @@ public class ClusterConfig implements JournalFactory {
         return jf.getJournal(resolver);
     }
 
+    /**
+     * @return disableAutoSync true if auto sync is disabled
+     */
+    public boolean isDisableAutoSync() {
+        return disableAutoSync;
+    }
 }

--- a/jackrabbit-core/src/main/java/org/apache/jackrabbit/core/config/RepositoryConfigurationParser.java
+++ b/jackrabbit-core/src/main/java/org/apache/jackrabbit/core/config/RepositoryConfigurationParser.java
@@ -181,6 +181,9 @@ public class RepositoryConfigurationParser extends ConfigurationParser {
     /** Name of the stopDelay configuration attribute. */
     public static final String STOP_DELAY_ATTRIBUTE = "stopDelay";
 
+    /** Name of the disableAutoSync configuration attribute. */
+    public static final String DISABLE_AUTO_SYNC_ATTRIBUTE = "disableAutoSync";
+
     /** Name of the default search index implementation class. */
     public static final String DEFAULT_QUERY_HANDLER =
         "org.apache.jackrabbit.core.query.lucene.SearchIndex";
@@ -895,7 +898,11 @@ public class RepositoryConfigurationParser extends ConfigurationParser {
                         element, STOP_DELAY_ATTRIBUTE, "-1")));
 
                 JournalFactory jf = getJournalFactory(element, home, id);
-                return new ClusterConfig(id, syncDelay, stopDelay, jf);
+
+                boolean disableAutoSync = Boolean.parseBoolean(replaceVariables(getAttribute(
+                        element, DISABLE_AUTO_SYNC_ATTRIBUTE, "false")));
+
+                return new ClusterConfig(id, syncDelay, stopDelay, jf, disableAutoSync);
             }
         }
         return null;

--- a/jackrabbit-core/src/test/java/org/apache/jackrabbit/core/cluster/ClusterSyncTest.java
+++ b/jackrabbit-core/src/test/java/org/apache/jackrabbit/core/cluster/ClusterSyncTest.java
@@ -130,6 +130,33 @@ public class ClusterSyncTest extends JUnitTest {
     }
 
     /**
+     * Verify that a cluster node with sync disabled does not fetch results when changes
+     * are made.
+     *
+     * @throws Exception
+     */
+    public void testSyncDisabled() throws Exception {
+        // create channel on master and slave
+        LockEventChannel channel = master.createLockChannel(DEFAULT_WORKSPACE);
+        channel.setListener(new SimpleEventListener());
+
+        // add first entry
+        LockEvent event = new LockEvent(NodeId.randomId(), true, "admin");
+        channel.create(event.getNodeId(), event.isDeep(), event.getUserId()).ended(true);
+
+        // do not sync slave
+
+        // add second entry
+        event = new LockEvent(NodeId.randomId(), true, "admin");
+        channel.create(event.getNodeId(), event.isDeep(), event.getUserId()).ended(true);
+
+        long masterRevision = master.getRevision();
+        long slaveRevision = slave.getRevision();
+
+        assertTrue(masterRevision > slaveRevision);
+    }
+
+    /**
      * Create a cluster node, with a memory journal referencing a list of records.
      *
      * @param id cluster node id


### PR DESCRIPTION
With this change you can now define your cluster config with an additional param to disable auto sync:

```
  <Cluster syncDelay="2000" disableAutoSync="true">
    <Journal class="org.apache.jackrabbit.core.journal.DatabaseJournal">
      ...
    </Journal>
  </Cluster>
```
With this we now have the ability to start a cluster node, allow it to synchronize to the latest journal revision at startup and then stop without worrying about any additional changes being sync'd via the normal journal sync process. The use case is to define a node like this to periodically launch, get the latest updates, stop and then save a backup.

I would be happy to provide a different unit test if you can suggest what sort of test you'd like to see since this is a very minimal change.