### PR TITLE
JCR-5160 Generate Jacoco Report in default location to be picked up by

### DIFF
--- a/jackrabbit-parent/pom.xml
+++ b/jackrabbit-parent/pom.xml
@@ -110,12 +110,6 @@
               </execution>
             </executions>
           </plugin>
-          <plugin>
-            <artifactId>maven-surefire-plugin</artifactId>
-            <configuration>
-              <skipTests>true</skipTests>
-            </configuration>
-          </plugin>
         </plugins>
       </build>
     </profile>
@@ -134,12 +128,6 @@
                 </goals>
               </execution>
             </executions>
-          </plugin>
-          <plugin>
-            <artifactId>maven-surefire-plugin</artifactId>
-            <configuration>
-              <skipTests>true</skipTests>
-            </configuration>
           </plugin>
         </plugins>
       </build>
@@ -263,26 +251,25 @@
         <version>0.8.13</version>
         <executions>
           <execution>
-            <id>pre-unit-test</id>
+            <id>prepare-jacoco-agent</id>
             <goals>
               <goal>prepare-agent</goal>
             </goals>
             <configuration>
+              <!-- the same agent parametrization is used for both ITs/UTs -->
               <skip>${skip.coverage}</skip>
-              <destFile>${project.build.directory}/coverage-reports/jacoco-ut.exec</destFile>
               <propertyName>test.opts.coverage</propertyName>
+              <!-- this is default, but make it more explicit, i.e. ITs just extend the existing execution data file-->
+              <append>true</append>
             </configuration>
           </execution>
           <execution>
-            <id>post-unit-test</id>
-            <phase>test</phase>
+            <id>generate-jacoco-report</id>
             <goals>
               <goal>report</goal>
             </goals>
             <configuration>
               <skip>${skip.coverage}</skip>
-              <dataFile>${project.build.directory}/coverage-reports/jacoco-ut.exec</dataFile>
-              <outputDirectory>${project.reporting.outputDirectory}/jacoco-ut</outputDirectory>
             </configuration>
           </execution>
           <execution>
@@ -291,7 +278,6 @@
               <goal>check</goal>
             </goals>
             <configuration>
-              <dataFile>${project.build.directory}/coverage-reports/jacoco-ut.exec</dataFile>
               <rules>
                 <rule>
                   <element>BUNDLE</element>


### PR DESCRIPTION
SonarScanner for Maven

The same agent is used for both ITs/UTs, one aggregate report is being used.