### PR TITLE
pom.xml changes for running FirstHop.java with jackrabbit 2.22.x

### DIFF
--- a/examples/jackrabbit-firsthops/pom.xml
+++ b/examples/jackrabbit-firsthops/pom.xml
@@ -42,6 +42,13 @@
    <version>2.12.1</version>
   </dependency>
 
+  <!-- Jackrabbit JCR Commons -->
+  <dependency>
+   <groupId>org.apache.jackrabbit</groupId>
+   <artifactId>jackrabbit-jcr-commons</artifactId>
+   <version>2.22.2</version>
+  </dependency>
+    
   <!-- Jackrabbit Oak content repository -->
   <!--
     Comment out above jackrabbit-core and uncomment
@@ -60,8 +67,16 @@
   <dependency>
    <groupId>org.slf4j</groupId>
    <artifactId>slf4j-log4j12</artifactId>
+   <version>1.7.36</version>
   </dependency>
 
+  <!-- Derby database for Jackrabbit (older compatible version) -->
+  <dependency>
+   <groupId>org.apache.derby</groupId>
+   <artifactId>derby</artifactId>
+   <version>10.14.2.0</version>
+  </dependency>
+    
  </dependencies>
 
  <build>
@@ -70,11 +85,10 @@
    <plugin>
     <groupId>org.apache.maven.plugins</groupId>
     <artifactId>maven-compiler-plugin</artifactId>
-    <version>2.3.2</version>
+     <version>3.8.1</version>
     <configuration>
-     <compilerVersion>1.5</compilerVersion>
-     <source>1.5</source>
-     <target>1.5</target>
+     <source>11</source>
+     <target>11</target>
      <debug>true</debug>
      <showDeprecation>false</showDeprecation>
      <showWarnings>true</showWarnings>

--- a/examples/jackrabbit-firsthops/pom.xml
+++ b/examples/jackrabbit-firsthops/pom.xml
@@ -19,6 +19,13 @@
  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
  <modelVersion>4.0.0</modelVersion>
 
+  <parent>
+    <groupId>org.apache.jackrabbit</groupId>
+    <artifactId>jackrabbit-parent</artifactId>
+    <version>2.22.2</version>
+    <relativePath>../../jackrabbit-parent/pom.xml</relativePath>
+  </parent>
+
  <groupId>org.apache.jackrabbit</groupId>
  <artifactId>jackrabbit-firsthops</artifactId>
  <version>0.1-SNAPSHOT</version>
@@ -30,9 +37,8 @@
 
   <!-- The JCR API -->
   <dependency>
-   <groupId>javax.jcr</groupId>
-   <artifactId>jcr</artifactId>
-   <version>2.0</version>
+      <groupId>javax.jcr</groupId>
+      <artifactId>jcr</artifactId>
   </dependency>
 
   <!-- Jackrabbit content repository -->
@@ -43,12 +49,12 @@
   </dependency>
 
   <!-- Jackrabbit JCR Commons -->
-  <dependency>
-   <groupId>org.apache.jackrabbit</groupId>
-   <artifactId>jackrabbit-jcr-commons</artifactId>
-   <version>2.22.2</version>
+ <dependency>
+    <groupId>org.apache.jackrabbit</groupId>
+    <artifactId>jackrabbit-jcr-commons</artifactId>
+    <version>2.22.2</version>
   </dependency>
-    
+
   <!-- Jackrabbit Oak content repository -->
   <!--
     Comment out above jackrabbit-core and uncomment
@@ -67,36 +73,10 @@
   <dependency>
    <groupId>org.slf4j</groupId>
    <artifactId>slf4j-log4j12</artifactId>
-   <version>1.7.36</version>
+    <version>${slf4j.version}</version>
+  <!-- <version>1.7.36</version>-->
   </dependency>
-
-  <!-- Derby database for Jackrabbit (older compatible version) -->
-  <dependency>
-   <groupId>org.apache.derby</groupId>
-   <artifactId>derby</artifactId>
-   <version>10.14.2.0</version>
-  </dependency>
-    
  </dependencies>
-
- <build>
-  <plugins>
-
-   <plugin>
-    <groupId>org.apache.maven.plugins</groupId>
-    <artifactId>maven-compiler-plugin</artifactId>
-     <version>3.8.1</version>
-    <configuration>
-     <source>11</source>
-     <target>11</target>
-     <debug>true</debug>
-     <showDeprecation>false</showDeprecation>
-     <showWarnings>true</showWarnings>
-     <optimize>false</optimize>
-    </configuration>
-   </plugin>
-  </plugins>
- </build>
 
 </project>
 

--- a/examples/jackrabbit-firsthops/pom.xml
+++ b/examples/jackrabbit-firsthops/pom.xml
@@ -39,7 +39,7 @@
   <dependency>
    <groupId>org.apache.jackrabbit</groupId>
    <artifactId>jackrabbit-core</artifactId>
-   <version>2.12.1</version>
+   <version>2.22.2</version>
   </dependency>
 
   <!-- Jackrabbit JCR Commons -->


### PR DESCRIPTION
From examples, FirstHop doesn't work as is from GitHub when 2.22.x is installed.
Made changes to pom.xml to address following issues
1) JDK version
2) Added dependency for missing jackrabbit-jcr-commons
3) Added version for   <version>1.7.36</version>
4) Added org.apache.derby version as 10.14.2.0 to address missing EmbeddedDriver class issue while running FirstHop.java using the command   mvn exec:java -Dexec.mainClass="org.apache.jackrabbit.firsthops.FirstHop"