### PR TITLE
JCR-4521: Update commons-dbcp dependency to 2.14.0

### DIFF
--- a/jackrabbit-core/pom.xml
+++ b/jackrabbit-core/pom.xml
@@ -233,9 +233,9 @@ org.apache.jackrabbit.core.version.RemoveAndAddVersionLabelXATest#testVersionLab
       <artifactId>commons-io</artifactId>
     </dependency>
     <dependency>
-      <groupId>commons-dbcp</groupId>
-      <artifactId>commons-dbcp</artifactId>
-      <version>1.4</version>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-dbcp2</artifactId>
+      <version>2.14.0</version>
     </dependency>
     <dependency>
       <groupId>javax.jcr</groupId>

--- a/jackrabbit-core/src/test/java/org/apache/jackrabbit/core/util/db/ConnectionFactoryTest.java
+++ b/jackrabbit-core/src/test/java/org/apache/jackrabbit/core/util/db/ConnectionFactoryTest.java
@@ -24,7 +24,7 @@ import javax.sql.DataSource;
 
 import junit.framework.TestCase;
 
-import org.apache.commons.dbcp.BasicDataSource;
+import org.apache.commons.dbcp2.BasicDataSource;
 import org.apache.derby.iapi.jdbc.EngineConnection;
 import org.apache.jackrabbit.core.config.ConfigurationException;
 import org.apache.jackrabbit.core.config.DataSourceConfig;
@@ -146,7 +146,7 @@ public class ConnectionFactoryTest extends TestCase {
     }
 
     private void assertPoolDefaults(BasicDataSource ds, String validationQuery, int maxCons) {
-        assertEquals(maxCons, ds.getMaxActive());
+        assertEquals(maxCons, ds.getMaxTotal());
         assertEquals(validationQuery, ds.getValidationQuery());
         assertTrue(ds.getDefaultAutoCommit());
         assertFalse(ds.getTestOnBorrow());

--- a/jackrabbit-data/pom.xml
+++ b/jackrabbit-data/pom.xml
@@ -86,9 +86,9 @@
 			<artifactId>commons-io</artifactId>
 		</dependency>
 		<dependency>
-			<groupId>commons-dbcp</groupId>
-			<artifactId>commons-dbcp</artifactId>
-			<version>1.4</version>
+			<groupId>org.apache.commons</groupId>
+			<artifactId>commons-dbcp2</artifactId>
+			<version>2.14.0</version>
       <optional>true</optional>
 		</dependency>
 		<dependency>

--- a/jackrabbit-data/src/main/java/org/apache/jackrabbit/core/util/db/ConnectionFactory.java
+++ b/jackrabbit-data/src/main/java/org/apache/jackrabbit/core/util/db/ConnectionFactory.java
@@ -30,9 +30,9 @@ import javax.naming.Context;
 import javax.naming.NamingException;
 import javax.sql.DataSource;
 
-import org.apache.commons.dbcp.BasicDataSource;
-import org.apache.commons.dbcp.DelegatingConnection;
-import org.apache.commons.pool.impl.GenericObjectPool;
+import org.apache.commons.dbcp2.BasicDataSource;
+import org.apache.commons.dbcp2.DelegatingConnection;
+import org.apache.commons.pool2.impl.GenericObjectPoolConfig;
 import org.apache.jackrabbit.core.config.DataSourceConfig;
 import org.apache.jackrabbit.core.config.DataSourceConfig.DataSourceDefinition;
 import org.apache.jackrabbit.util.Base64;
@@ -102,7 +102,7 @@ public final class ConnectionFactory {
                     BasicDataSource bds =
                         getDriverDataSource(driverClass, def.getUrl(), def.getUser(), def.getPassword());
                     if (def.getMaxPoolSize() > 0) {
-                        bds.setMaxActive(def.getMaxPoolSize());
+                        bds.setMaxTotal(def.getMaxPoolSize());
                     }
                     if (def.getValidationQuery() != null && !"".equals(def.getValidationQuery().trim())) {
                         bds.setValidationQuery(def.getValidationQuery());
@@ -348,12 +348,14 @@ public final class ConnectionFactory {
         ds.setTestWhileIdle(true);
         ds.setTimeBetweenEvictionRunsMillis(600000); // 10 Minutes
         ds.setMinEvictableIdleTimeMillis(60000); // 1 Minute
-        ds.setMaxActive(-1); // unlimited
-        ds.setMaxIdle(GenericObjectPool.DEFAULT_MAX_IDLE + 10);
+        ds.setMaxTotal(-1); // unlimited
+        ds.setMaxIdle(GenericObjectPoolConfig.DEFAULT_MAX_IDLE + 10);
         ds.setValidationQuery(guessValidationQuery(url));
         ds.setAccessToUnderlyingConnectionAllowed(true);
         ds.setPoolPreparedStatements(Boolean.valueOf(System.getProperty(SYSTEM_PROPERTY_POOL_PREPARED_STATEMENTS, "true")));
         ds.setMaxOpenPreparedStatements(-1); // unlimited
+        // this helps to discover unusable connections of a shut-down database without executing a validation query
+        ds.setCacheState(false);
         return ds;
     }
 


### PR DESCRIPTION
This PR is a partial fix of [JCR-4521](https://issues.apache.org/jira/browse/JCR-4521). The request for more customization possibilities is not addressed here. Most of the changes are identical to the patch [(JCR-4521.diff)](https://issues.apache.org/jira/secure/attachment/12991379/12991379_JCR-4521.diff) from @reschke.

During the execution of the test suite the Derby database will be shut down several times. The associated database connections remain in the pool but are no longer valid and lead to test errors. I have discovered two options to fix the tests:

1. Activate `testOnBorrow` and execute a validation query. With Commons DBCP 1.x this is not needed for the tests (see 2).
2. Deactivate `cacheState`. If the caching of the `readOnly` and `autoCommit` settings is deactivated, these will be reset when returning a connection from the pool. During this operation the invalid connections will be discovered and thrown away. I have chosen this option in the implementation, because it corresponds to the behavior when using Commons DBCP 1.x. (The validation query in option 1 may have different runtime characteristics.)

These options don't work:

3. _Close the pool_ after a database shut-down: The data source (i.e. the pool) is cached in the class `ConnectionFactory` and may still be reused. Without reopening the pool this will not work.
4. _Restart (atomically close and reopen) the pool_  after a database shut-down: When the new pool is created a new connection is created to validate the pool. This starts the database again. But this database instance will soon get corrupted and unusable when its files in the file system are deleted during set up of the next test case. So the database has to stay shut-down until its files have been removed.