### PR TITLE
JCR-5173: Fix sonar.coverage.jacoco.xmlReportPaths for modules

### DIFF
--- a/.mvn/README.md
+++ b/.mvn/README.md
@@ -1,0 +1,1 @@
+Used for determining [`maven.multiModuleProjectDirectory`](https://issues.apache.org/jira/browse/MNG-5786).

--- a/jackrabbit-parent/pom.xml
+++ b/jackrabbit-parent/pom.xml
@@ -80,7 +80,8 @@
     <minimalMavenBuildVersion>3.6.1</minimalMavenBuildVersion><!-- due to https://issues.apache.org/jira/browse/MNG-6059 -->
     
     <!-- this project uses cross-module reports with one aggregate, https://docs.sonarsource.com/sonarcloud/enriching/test-coverage/java-test-coverage/#add-coverage-in-a-multi-module-maven-project -->
-    <sonar.coverage.jacoco.xmlReportPaths>${project.basedir}/target/site/jacoco-aggregate/jacoco.xml</sonar.coverage.jacoco.xmlReportPaths>
+    <!-- "maven.multiModuleProjectDirectory" is undocumented (https://issues.apache.org/jira/browse/MNG-6589) but the only way to reference the aggregate root directory in Maven 3.x-->
+    <sonar.coverage.jacoco.xmlReportPaths>${maven.multiModuleProjectDirectory}/target/site/jacoco-aggregate/jacoco.xml</sonar.coverage.jacoco.xmlReportPaths>
     <!-- this should be the same as the exclusions for jacoco, compare with https://groups.google.com/g/sonarqube/c/VwEE_ZD2KzI -->
     <sonar.coverage.exclusions>**/org/apache/jackrabbit/test/**</sonar.coverage.exclusions>
     <!-- exclude test code from analysis-->


### PR DESCRIPTION
All modules must refer to the single aggregate report to extract coverage information only from there.