### PR TITLE
Fix 'occured' -> 'occurred' typos in 2 files

### DIFF
--- a/jackrabbit-core/src/main/java/org/apache/jackrabbit/core/persistence/util/BLOBStore.java
+++ b/jackrabbit-core/src/main/java/org/apache/jackrabbit/core/persistence/util/BLOBStore.java
@@ -48,7 +48,7 @@ public interface BLOBStore {
      *               {@link #createId(PropertyId, int)}
      * @param in     stream containing the BLOB data
      * @param size   size of the BLOB data
-     * @throws Exception if an error occured
+     * @throws Exception if an error occurred
      */
     void put(String blobId, InputStream in, long size) throws Exception;
 
@@ -58,7 +58,7 @@ public interface BLOBStore {
      * @param blobId identifier of the BLOB data as returned by
      *               {@link #createId(PropertyId, int)}
      * @return an input stream that delivers the BLOB data
-     * @throws Exception if an error occured
+     * @throws Exception if an error occurred
      */
     InputStream get(String blobId) throws Exception;
 
@@ -70,7 +70,7 @@ public interface BLOBStore {
      * @return <code>true</code> if BLOB data with the given id exists and has
      *         been successfully removed, <code>false</code> if there's no BLOB
      *         data with the given id.
-     * @throws Exception if an error occured
+     * @throws Exception if an error occurred
      */
     boolean remove(String blobId) throws Exception;
 }

--- a/jackrabbit-jcr-commons/src/main/java/org/apache/jackrabbit/value/ValueHelper.java
+++ b/jackrabbit-jcr-commons/src/main/java/org/apache/jackrabbit/value/ValueHelper.java
@@ -696,7 +696,7 @@ public class ValueHelper {
      *                     as <code>"_x0020_"</code> within he output string.
      * @return a string representation of the given value.
      * @throws IllegalStateException if the given value is in an illegal state
-     * @throws RepositoryException   if an error occured during the serialization.
+     * @throws RepositoryException   if an error occurred during the serialization.
      */
     public static String serialize(Value value, boolean encodeBlanks)
             throws IllegalStateException, RepositoryException {
@@ -722,9 +722,9 @@ public class ValueHelper {
      * @param enforceBase64 if <code>true</code>, base64 encoding will always be used
      * @param writer       writer to output the encoded data
      * @throws IllegalStateException if the given value is in an illegal state
-     * @throws IOException           if an i/o error occured during the
+     * @throws IOException           if an i/o error occurred during the
      *                               serialization
-     * @throws RepositoryException   if an error occured during the serialization.
+     * @throws RepositoryException   if an error occurred during the serialization.
      */
     public static void serialize(Value value, boolean encodeBlanks, boolean enforceBase64,
                                  Writer writer)


### PR DESCRIPTION
Trivial spelling fix in two source files — `occured` → `occurred`.

All occurrences are in public API Javadoc:

- `jackrabbit-core/.../BLOBStore.java` — three `@throws` tags on `put` / `get` / `remove`.
- `jackrabbit-jcr-commons/.../ValueHelper.java` — three `@throws` tags on the two `serialize()` overloads.

No functional changes.