### PR TITLE
JCR-5095: retry token creation on concurrent modification of the token parent

### DIFF
--- a/jackrabbit-core/src/main/java/org/apache/jackrabbit/core/security/authentication/token/TokenProvider.java
+++ b/jackrabbit-core/src/main/java/org/apache/jackrabbit/core/security/authentication/token/TokenProvider.java
@@ -31,6 +31,8 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 import javax.jcr.AccessDeniedException;
+import javax.jcr.InvalidItemStateException;
+import javax.jcr.ItemNotFoundException;
 import javax.jcr.NamespaceRegistry;
 import javax.jcr.Node;
 import javax.jcr.Property;
@@ -75,6 +77,13 @@ public class TokenProvider extends ProtectedItemModifier {
     private static final Name TOKENS_NT_NAME = NameConstants.NT_UNSTRUCTURED;
 
     private static final char DELIM = '_';
+
+    /**
+     * Number of attempts to persist a new token node before giving up. Concurrent logins
+     * of the same user write below a shared token parent and may invalidate each other's
+     * pending changes (JCR-5095).
+     */
+    private static final int CREATE_TOKEN_MAX_ATTEMPTS = 3;
 
     private static final Set<String> RESERVED_ATTRIBUTES = new HashSet(3);
     static {
@@ -146,6 +155,39 @@ public class TokenProvider extends ProtectedItemModifier {
      */
     private TokenInfo createToken(User user, Map<String, ?> attributes) throws RepositoryException {
         String error = "Failed to create login token. ";
+        // Concurrent logins of the same user add token nodes below the very same token
+        // parent. A concurrent commit below that parent may invalidate the pending changes
+        // of this session, so that the token node can neither be saved
+        // (InvalidItemStateException) nor resolved afterwards (ItemNotFoundException while
+        // building its path). Both are transient, so retry with a refreshed session,
+        // analogous to the conflict handling in getTokenParent (JCR-5095).
+        for (int attempt = 1; ; attempt++) {
+            try {
+                return createTokenNode(user, attributes, error);
+            } catch (InvalidItemStateException | ItemNotFoundException e) {
+                if (attempt >= CREATE_TOKEN_MAX_ATTEMPTS) {
+                    throw e;
+                }
+                log.debug("Conflict while creating login token (attempt {}) -> retrying", attempt, e);
+                // discard the token node that could not be persisted before retrying
+                session.refresh(false);
+            }
+        }
+    }
+
+    /**
+     * Creates and persists a single token node below the token parent of the given user.
+     *
+     * @param user       The user for which a new token should be created.
+     * @param attributes The attributes associated with the new token.
+     * @param error      Prefix used for log messages.
+     * @return A new {@code TokenInfo} or {@code null} if the token could not be created.
+     * @throws InvalidItemStateException If the token node could not be persisted because
+     *                                   the token parent was modified concurrently.
+     * @throws ItemNotFoundException If the token node could not be resolved after saving
+     *                               because the token parent was modified concurrently.
+     */
+    private TokenInfo createTokenNode(User user, Map<String, ?> attributes, String error) throws RepositoryException {
         NodeImpl tokenParent = getTokenParent(user);
         if (tokenParent != null) {
             try {


### PR DESCRIPTION
Retry token node creation when a concurrent login invalidates the pending changes.

### Problem

`TokenBasedLoginTest` fails intermittently on CI (JCR-5095, open since 2024-08). Two symptoms, both from the same race:

```
javax.jcr.LoginException: Failed to commit: Could not find child <uuid> of node <uuid>
  at TokenProvider.createToken(TokenProvider.java:173)   // session.save()
```

```
javax.jcr.LoginException: Failed to commit: failed to build path of <uuid>:
    <uuid> has no child entry for <uuid>                 // tokenNode.getPath()
```

### Cause

Concurrent logins of the same user each get their own session (`DefaultLoginModule.commit`) but add their token node below the *same* `.tokens` parent. When another session commits below that parent, this session's view of the parent can lose the child entry for its own pending token node. The failure then surfaces either while saving (`InvalidItemStateException` from `ItemSaveOperation.validateTransientItems`) or right after, while resolving the new node's path (`ItemNotFoundException` from `HierarchyManagerImpl`).

`getTokenParent` already handles exactly this kind of conflict for the concurrent creation of the token store itself — it refreshes the session and re-reads the parent. The creation of the token node below that parent had no such handling, so a single conflict failed the whole login.

### Change

Wrap the token node creation in a bounded retry (3 attempts) that discards the doomed transient state with `session.refresh(false)` and re-reads the token parent, mirroring the existing idiom in `getTokenParent`. The body of the old method is extracted unchanged into `createTokenNode`. After the last attempt the original exception is rethrown, so behaviour on persistent failures is unchanged.

This makes token creation tolerate the conflict; it does not remove the underlying core race in transient state handling, which is why JCR-5095 should stay open.

### Verification

`TokenBasedLoginTest` run repeatedly on a clean repository, macOS / JDK 24:

| | before | after |
|---|---|---|
| runs with the race failure | 1 of 12 | 0 of 54 |

One run in the "after" set failed with an error I did not manage to capture, and it did not recur in 30 further runs, so I cannot say what it was. The baseline showed unrelated environment errors ("Failed to get Repository instance", stale repository lock) at a comparable rate.

`mvn test -Dtest='org.apache.jackrabbit.core.security.authentication.**'` — 114 tests, all passing.

Note for reviewers: `session.refresh(false)` discards *all* transient changes on the session. That is safe for `DefaultLoginModule`, which creates a dedicated session for token creation, but `TokenBasedAuthentication.createToken` is public and accepts a caller-supplied session. The pre-existing `getTokenParent` conflict path already calls `session.refresh(false)` on the same session, so this is not a new hazard, but it now applies to a second code path — happy to scope it differently if you prefer.
